### PR TITLE
adding additional fields regardless exception

### DIFF
--- a/src/main/java/org/graylog2/log4j2/GelfAppender.java
+++ b/src/main/java/org/graylog2/log4j2/GelfAppender.java
@@ -126,9 +126,12 @@ public class GelfAppender extends AbstractAppender {
             builder.additionalField("exceptionClass", thrown.getClass().getCanonicalName());
             builder.additionalField("exceptionMessage", thrown.getMessage());
             builder.additionalField("exceptionStackTrace", stackTraceBuilder.toString());
-            builder.additionalFields(additionalFields);
 
             builder.fullMessage(event.getMessage().getFormattedMessage() + "\n\n" + stackTraceBuilder.toString());
+        }
+        
+        if (!additionalFields.isEmpty()) {
+        	builder.additionalFields(additionalFields);
         }
 
         try {


### PR DESCRIPTION
custom fields should always be printed, even though no exception was thrown.
