### PR TITLE
Adding TLS support for TCP transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     </parent>
 
     <groupId>org.graylog2.log4j2</groupId>
-    <artifactId>log4j2-gelf-tls</artifactId>
-    <version>1.1.1</version>
+    <artifactId>log4j2-gelf</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>log4j2-gelf</name>
     <description>GELF Appender for Log4j2</description>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     </parent>
 
     <groupId>org.graylog2.log4j2</groupId>
-    <artifactId>log4j2-gelf</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <artifactId>log4j2-gelf-tls</artifactId>
+    <version>1.1.1</version>
 
     <name>log4j2-gelf</name>
     <description>GELF Appender for Log4j2</description>

--- a/src/main/java/org/graylog2/log4j2/GelfAppender.java
+++ b/src/main/java/org/graylog2/log4j2/GelfAppender.java
@@ -211,6 +211,7 @@ public class GelfAppender extends AbstractAppender {
                                                   @PluginAttribute(value = "reconnectDelay", defaultInt = 500) Integer reconnectDelay,
                                                   @PluginAttribute(value = "sendBufferSize", defaultInt = -1) Integer sendBufferSize,
                                                   @PluginAttribute(value = "tcpNoDelay", defaultBoolean = false) Boolean tcpNoDelay,
+                                                  @PluginAttribute(value = "tcpUseTls", defaultBoolean = false) Boolean tcpUseTls,
                                                   @PluginAttribute(value = "tcpKeepAlive", defaultBoolean = false) Boolean tcpKeepAlive,
                                                   @PluginAttribute(value = "includeSource", defaultBoolean = true) Boolean includeSource,
                                                   @PluginAttribute(value = "includeThreadContext", defaultBoolean = true) Boolean includeThreadContext,
@@ -246,6 +247,10 @@ public class GelfAppender extends AbstractAppender {
                 .sendBufferSize(sendBufferSize)
                 .tcpNoDelay(tcpNoDelay)
                 .tcpKeepAlive(tcpKeepAlive);
+
+        if(tcpUseTls) {
+            gelfConfiguration.enableTls();
+        }
 
         return new GelfAppender(name, layout, filter, ignoreExceptions, gelfConfiguration, hostName, includeSource,
                 includeThreadContext, includeStackTrace, additionalFields);


### PR DESCRIPTION
Simply exposes the `GelfConfiguration.enableTls()` method through the config attribute `tcpUseTls`.
