### PR TITLE
Add possibility to include full stacktraces with causing exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
         <maven>3.0.1</maven>
@@ -77,6 +78,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>

--- a/src/test/java/org/graylog2/log4j2/GelfAppenderTest.java
+++ b/src/test/java/org/graylog2/log4j2/GelfAppenderTest.java
@@ -9,6 +9,7 @@ import org.junit.AfterClass;
 import org.junit.Test;
 
 public class GelfAppenderTest {
+
     @Test
     public void testLog() {
         final Logger logger = LogManager.getLogger("test");
@@ -28,7 +29,7 @@ public class GelfAppenderTest {
         final Logger logger = LogManager.getLogger("test");
 
         try {
-            throw new Exception("Test");
+            throw new Exception("Test", new Exception("Cause", new RuntimeException("Inner Cause")));
         } catch (Exception e) {
             e.fillInStackTrace();
             logger.error("Hello World", e);

--- a/src/test/java/org/graylog2/log4j2/GelfAppenderThrowableTest.java
+++ b/src/test/java/org/graylog2/log4j2/GelfAppenderThrowableTest.java
@@ -1,0 +1,186 @@
+package org.graylog2.log4j2;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.Message;
+import org.graylog2.gelfclient.GelfMessage;
+import org.graylog2.gelfclient.transport.GelfTransport;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class GelfAppenderThrowableTest {
+
+    private GelfTransport mockedGelfTransport;
+
+    @Before
+    public void setUp() {
+        mockedGelfTransport = mock(GelfTransport.class);
+    }
+
+    @Test
+    public void shouldNotAddExceptionToFullMessage() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(true, true);
+        final LogEvent event = createLogEventMock();
+        given(event.getThrown()).willReturn(new RuntimeException("Outer Exception", new Exception("Inner Exception")));
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final String fullMessage = gelfMessageCaptor.getValue().getFullMessage();
+        assertThat(fullMessage, is("Some Message"));
+    }
+
+    @Test
+    public void shouldAppendExceptionClassAndMessage() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(true, true);
+        final LogEvent event = createLogEventMock();
+        given(event.getThrown()).willReturn(new RuntimeException("Outer Exception", new Exception("Inner Exception")));
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final Object exceptionMessage = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_MESSAGE);
+        final Object exceptionClass = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_CLASS);
+        assertThat(exceptionMessage, notNullValue());
+        assertThat(exceptionMessage.toString(), containsString("Outer Exception"));
+        assertThat(exceptionClass, notNullValue());
+        assertThat(exceptionClass.toString(), containsString("java.lang.RuntimeException"));
+    }
+
+    @Test
+    public void shouldNotAppendExceptionInformationIfNotRequested() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(false, false);
+        final LogEvent event = createLogEventMock();
+        given(event.getThrown()).willReturn(new RuntimeException("Outer Exception", new Exception("Inner Exception")));
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final Object exceptionMessage = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_MESSAGE);
+        final Object exceptionClass = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_CLASS);
+        final Object exceptionStackTrace = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_STACK_TRACE);
+        assertThat(exceptionMessage, nullValue());
+        assertThat(exceptionClass, nullValue());
+        assertThat(exceptionStackTrace, nullValue());
+    }
+
+    @Test
+    public void shouldNotFailIfNoExceptionAvailable() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(false, false);
+        final LogEvent event = createLogEventMock();
+        given(event.getThrown()).willReturn(null);
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final Object exceptionMessage = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_MESSAGE);
+        final Object exceptionClass = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_CLASS);
+        final Object exceptionStackTrace = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_STACK_TRACE);
+        assertThat(exceptionMessage, nullValue());
+        assertThat(exceptionClass, nullValue());
+        assertThat(exceptionStackTrace, nullValue());
+    }
+
+    @Test
+    public void shouldAppendStacktraceWithCauses() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(true, true);
+        final LogEvent event = createLogEventMock();
+        given(event.getThrown()).willReturn(new RuntimeException("Outer Exception", new Exception("Inner Exception")));
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final Object exceptionStackTrace = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_STACK_TRACE);
+        assertThat(exceptionStackTrace, notNullValue());
+        assertThat(exceptionStackTrace.toString(), containsString("Caused by: java.lang.Exception: Inner Exception"));
+    }
+
+    @Test
+    public void shouldAppendStacktraceWithoutCauses() throws InterruptedException {
+        // given
+        final GelfAppender gelfAppender = createGelfAppender(true, false);
+        final LogEvent event = createLogEventMock();
+        final RuntimeException exception = new RuntimeException("Outer Exception", new Exception("Inner Exception"));
+        given(event.getThrown()).willReturn(exception);
+
+        // when
+        gelfAppender.append(event);
+
+        // then
+        ArgumentCaptor<GelfMessage> gelfMessageCaptor = ArgumentCaptor.forClass(GelfMessage.class);
+        verify(mockedGelfTransport).send(gelfMessageCaptor.capture());
+        final Object exceptionStackTrace = gelfMessageCaptor.getValue()
+                .getAdditionalFields()
+                .get(GelfAppender.ADD_FIELD_EXCEPTION_STACK_TRACE);
+        assertThat(exceptionStackTrace, notNullValue());
+
+        assertThat(exceptionStackTrace.toString(), is(gelfAppender.getSimpleStacktraceAsString(exception)));
+        assertThat(exceptionStackTrace.toString(), not(containsString("Caused by: java.lang.Exception: Inner Exception")));
+    }
+
+    private GelfAppender createGelfAppender(final boolean includeStackTrace, final boolean includeExceptionCause) {
+        GelfAppender gelfAppender = new GelfAppender("appender", null, null, false, null, "host", false, false, includeStackTrace,
+                null, includeExceptionCause);
+        gelfAppender.client = mockedGelfTransport;
+        return gelfAppender;
+    }
+
+    private LogEvent createLogEventMock() {
+        final Message message = mock(Message.class);
+        given(message.getFormattedMessage()).willReturn("Some Message");
+
+        final LogEvent event = mock(LogEvent.class);
+        given(event.getMessage()).willReturn(message);
+        given(event.getLevel()).willReturn(Level.ALL);
+        return event;
+    }
+}


### PR DESCRIPTION
```
- It is desirable to have a full stacktrace including the causing exceptions in logs
- To be backwards compatible, an optional flag is added
- Full message will no longer contain stacktrace, since it is redundant
```
