### PR TITLE
OSGI (Pax Logging) support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,38 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>osgi</classifier>
+                            <instructions>
+                                <Fragment-Host>org.ops4j.pax.logging.pax-logging-log4j2</Fragment-Host>
+                                <Export-Package>!*</Export-Package>
+                                <Import-Package>
+                                    org.slf4j.*,
+                                    javax.*,
+                                    sun.misc,
+                                    <!-- do not import other logging APIs -->
+                                    !org.apache.commons.logging.*,
+                                    !org.apache.log4j*,
+                                    !org.apache.logging.log4j*,
+                                    *;resolution:=optional
+                                </Import-Package>
+                                <Embed-Transitive>true</Embed-Transitive>
+                                <Embed-Dependency>*;artifactId=!slf4j-api;scope=compile;optional=false;type=!pom</Embed-Dependency>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Make additional OSGI compatible artifact with classifier "osgi". Implemented as Pax Logging Log4j2 backend fragment bundle. Tested in Apache Karaf 4.1.0 .